### PR TITLE
hook sql当只有一个值返回时，直接取值

### DIFF
--- a/backend/zerorunner/steps/step_sql_request.py
+++ b/backend/zerorunner/steps/step_sql_request.py
@@ -32,6 +32,8 @@ def run_sql_request(runner: SessionRunner,
         )
 
         data = db_engine.fetchall(step.sql_request.sql)
+        if isinstance(data, list) and len(data) == 1:
+            data = next(iter(data[0].values()))
         variables = {step.sql_request.variable_name: data}
         runner.with_variables(variables)
         step_result.export_vars.update(variables)


### PR DESCRIPTION
现在是会返回一个列表[{'key':value}]这样的形式，修改后只返回value。
对已有的sql hook会有影响 😂